### PR TITLE
Request multiple credentials in pseudo-batch request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ reqwest-retry = "0.3"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 serde_urlencoded = "0.7"
-serde_with = "3.0"
+serde_with = { version = "3.0", features = ["macros"]}
 tokio = { version = "1.26.0", features = ["rt", "macros", "rt-multi-thread"] }
 url = { version = "2", features = ["serde"] }
 rsa = { version = "0.9.6", features = ["serde"] }

--- a/oid4vc-manager/src/servers/credential_issuer.rs
+++ b/oid4vc-manager/src/servers/credential_issuer.rs
@@ -12,11 +12,7 @@ use axum::{
 use axum_auth::AuthBearer;
 use oid4vc_core::Validator;
 use oid4vci::{
-    authorization_request::AuthorizationRequest,
-    credential_format_profiles::CredentialFormatCollection,
-    credential_request::{BatchCredentialRequest, CredentialRequest, OneOrManyKeyProofs},
-    credential_response::{BatchCredentialResponse, CredentialResponse, CredentialResponseType},
-    token_request::TokenRequest,
+    authorization_request::AuthorizationRequest, credential_format_profiles::CredentialFormatCollection, credential_request::{BatchCredentialRequest, CredentialRequest, OneOrManyKeyProofs}, credential_response::{BatchCredentialResponse, CredentialResponse, CredentialResponseType}, proof::KeyProofsType, token_request::TokenRequest, KeyProofType
 };
 use OneOrManyKeyProofs::{Proof, Proofs};
 use serde::de::DeserializeOwned;
@@ -178,8 +174,8 @@ async fn credential<S: Storage<CFC>, CFC: CredentialFormatCollection>(
     let credential_request_proofs = match credential_request.proof {
         Proof(None) => vec![],
         Proof(Some(proof)) => vec![proof],
-        Proofs(KeyProofsType::Jwt(proofs)) => proofs.map(|jwt| KeyProofType::Jwt(jwt)),
-        Proofs(KeyProofsType::Cwt(proofs)) => proofs.map(|cwt| KeyProofType::Cwt(cwt)),
+        Proofs(KeyProofsType::Jwt(proofs)) => proofs.into_iter().map(|jwt| KeyProofType::Jwt { jwt }).collect(),
+        Proofs(KeyProofsType::Cwt(proofs)) => proofs.into_iter().map(|cwt| KeyProofType::Cwt { cwt }).collect(),
     };
 
     let mut c_nonce = None;

--- a/oid4vc-manager/src/servers/credential_issuer.rs
+++ b/oid4vc-manager/src/servers/credential_issuer.rs
@@ -178,7 +178,8 @@ async fn credential<S: Storage<CFC>, CFC: CredentialFormatCollection>(
     let credential_request_proofs = match credential_request.proof {
         Proof(None) => vec![],
         Proof(Some(proof)) => vec![proof],
-        Proofs(proofs) => proofs,
+        Proofs(KeyProofsType::Jwt(proofs)) => proofs.map(|jwt| KeyProofType::Jwt(jwt)),
+        Proofs(KeyProofsType::Cwt(proofs)) => proofs.map(|cwt| KeyProofType::Cwt(cwt)),
     };
 
     let mut c_nonce = None;

--- a/oid4vc-manager/src/servers/credential_issuer.rs
+++ b/oid4vc-manager/src/servers/credential_issuer.rs
@@ -174,10 +174,11 @@ async fn credential<S: Storage<CFC>, CFC: CredentialFormatCollection>(
     Json(credential_request): Json<CredentialRequest<CFC>>,
 ) -> impl IntoResponse {
     // TODO: The bunch of unwrap's here should be replaced with error responses as described here: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-13.html#name-credential-error-response
+    // XXX(matzf): ignores all but the first proof of the pseudo-batch request. Should do batch issuance instead...
     let proof = credential_issuer_manager
         .credential_issuer
         .validate_proof(
-            credential_request.proof.unwrap(),
+            credential_request.proof.first().unwrap().clone(),
             Validator::Subject(credential_issuer_manager.credential_issuer.subject.clone()),
         )
         .await
@@ -215,7 +216,7 @@ async fn batch_credential<S: Storage<CFC>, CFC: CredentialFormatCollection>(
         let proof = credential_issuer_manager
             .credential_issuer
             .validate_proof(
-                credential_request.proof.unwrap(),
+                credential_request.proof.first().unwrap().clone(),
                 Validator::Subject(credential_issuer_manager.credential_issuer.subject.clone()),
             )
             .await

--- a/oid4vci/Cargo.toml
+++ b/oid4vci/Cargo.toml
@@ -18,6 +18,7 @@ getset.workspace = true
 lazy_static = "1.4"
 jsonwebtoken = "8.3"
 paste = "1.0"
+futures = "0.3.30"
 reqwest.workspace = true
 reqwest-middleware.workspace = true
 reqwest-retry.workspace = true

--- a/oid4vci/src/credential_request.rs
+++ b/oid4vci/src/credential_request.rs
@@ -5,21 +5,19 @@ use crate::{
 };
 use jsonwebtoken::jwk::Jwk;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, OneOrMany, skip_serializing_none};
-use serde_with::formats::PreferOne;
+use serde_with::skip_serializing_none;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq,Eq,Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum OneOrManyKeyProofs {
-    #[serde(rename="proof")]
+    #[serde(rename = "proof")]
     Proof(Option<KeyProofType>),
-    #[serde(rename="proofs")]
+    #[serde(rename = "proofs")]
     Proofs(Vec<KeyProofType>),
 }
 
 use OneOrManyKeyProofs::{Proof, Proofs};
 
 /// Credential Request as described here: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-13.html#name-credential-request
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct CredentialRequest<CFC = CredentialFormats<WithParameters>>
@@ -144,7 +142,7 @@ mod tests {
             jwt_vc_json
         );
     }
-    
+
     #[test]
     fn test_credential_request_many_serde_jwt_vc_json() {
         let jwt_vc_json = json!({
@@ -195,8 +193,12 @@ mod tests {
                         .into()
                 }),
                 proof: Proofs(vec![
-                    KeyProofType::Jwt { jwt: "eyJraWQiOiJkaWQ6ZXhhbXBsZ...KPxgihac0aW9EkL1nOzM".to_string() },
-                    KeyProofType::Jwt { jwt: "aslkjaslkaslkjasdlkjasdlk...lasdkasdlkasdlkjaslk".to_string() },
+                    KeyProofType::Jwt {
+                        jwt: "eyJraWQiOiJkaWQ6ZXhhbXBsZ...KPxgihac0aW9EkL1nOzM".to_string()
+                    },
+                    KeyProofType::Jwt {
+                        jwt: "aslkjaslkaslkjasdlkjasdlk...lasdkasdlkasdlkjaslk".to_string()
+                    },
                 ]),
                 credential_response_encryption: None
             }

--- a/oid4vci/src/credential_request.rs
+++ b/oid4vci/src/credential_request.rs
@@ -1,7 +1,7 @@
 use crate::{
     credential_format_profiles::{CredentialFormatCollection, CredentialFormats, WithParameters},
     credential_issuer::credential_issuer_metadata::CredentialResponseEncryption,
-    proof::KeyProofType,
+    proof::{KeyProofType, KeyProofsType},
 };
 use jsonwebtoken::jwk::Jwk;
 use serde::{Deserialize, Serialize};
@@ -12,7 +12,7 @@ pub enum OneOrManyKeyProofs {
     #[serde(rename = "proof")]
     Proof(Option<KeyProofType>),
     #[serde(rename = "proofs")]
-    Proofs(Vec<KeyProofType>),
+    Proofs(KeyProofsType),
 }
 
 use OneOrManyKeyProofs::{Proof, Proofs};
@@ -158,13 +158,12 @@ mod tests {
                   "degree": {}
                }
             },
-            "proofs": [{
-               "proof_type": "jwt",
-               "jwt": "eyJraWQiOiJkaWQ6ZXhhbXBsZ...KPxgihac0aW9EkL1nOzM"
-            }, {
-               "proof_type": "jwt",
-               "jwt": "aslkjaslkaslkjasdlkjasdlk...lasdkasdlkasdlkjaslk"
-            }]
+            "proofs": {
+               "jwt": [
+                  "eyJ0eXAiOiJvcGVuaWQ0dmNpL...Lb9zioZoipdP-jvh1WlA",
+                  "eyJraWQiOiJkaWQ6ZXhhbXBsZ...KPxgihac0aW9EkL1nOzM"
+                ],
+            },
         });
 
         let credential_request_jwt_vc_json: CredentialRequest = serde_json::from_value(jwt_vc_json.clone()).unwrap();
@@ -192,14 +191,10 @@ mod tests {
                     )
                         .into()
                 }),
-                proof: Proofs(vec![
-                    KeyProofType::Jwt {
-                        jwt: "eyJraWQiOiJkaWQ6ZXhhbXBsZ...KPxgihac0aW9EkL1nOzM".to_string()
-                    },
-                    KeyProofType::Jwt {
-                        jwt: "aslkjaslkaslkjasdlkjasdlk...lasdkasdlkasdlkjaslk".to_string()
-                    },
-                ]),
+                proof: Proofs(KeyProofsType::Jwt(vec![
+                      "eyJ0eXAiOiJvcGVuaWQ0dmNpL...Lb9zioZoipdP-jvh1WlA".to_string(),
+                      "eyJraWQiOiJkaWQ6ZXhhbXBsZ...KPxgihac0aW9EkL1nOzM".to_string(),
+                    ])),
                 credential_response_encryption: None
             }
         );

--- a/oid4vci/src/credential_response.rs
+++ b/oid4vci/src/credential_response.rs
@@ -15,6 +15,8 @@ pub struct CredentialResponse {
 #[skip_serializing_none]
 #[derive(Serialize, Debug, PartialEq, Deserialize)]
 pub struct BatchCredentialResponse {
+    #[serde(alias="credentials")]
+    #[serde(alias="credential")]
     pub credential_responses: Vec<CredentialResponseType>,
     pub c_nonce: Option<String>,
     pub c_nonce_expires_in: Option<u64>,

--- a/oid4vci/src/credential_response.rs
+++ b/oid4vci/src/credential_response.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
-use serde_with::skip_serializing_none;
+use serde_with::formats::PreferMany;
+use serde_with::{serde_as, skip_serializing_none, OneOrMany};
 
 /// Credential Response as described here: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-13.html#name-credential-response
+#[serde_as]
 #[skip_serializing_none]
 #[derive(Serialize, Debug, PartialEq, Deserialize, Clone)]
 pub struct CredentialResponse {
@@ -15,8 +17,6 @@ pub struct CredentialResponse {
 #[skip_serializing_none]
 #[derive(Serialize, Debug, PartialEq, Deserialize)]
 pub struct BatchCredentialResponse {
-    #[serde(alias="credentials")]
-    #[serde(alias="credential")]
     pub credential_responses: Vec<CredentialResponseType>,
     pub c_nonce: Option<String>,
     pub c_nonce_expires_in: Option<u64>,
@@ -30,6 +30,7 @@ pub enum CredentialResponseType {
         transaction_id: String,
     },
     Immediate {
+        #[serde(alias = "credentials")] // XXX Accepts "credential" with multiple. Meh, good enough...
         credential: serde_json::Value,
         notification_id: Option<String>,
     },
@@ -54,6 +55,29 @@ mod tests {
             serialized,
             json!({
                 "transaction_id": "123",
+                "c_nonce": "456",
+                "c_nonce_expires_in": 789
+            })
+        );
+        let deserialized: CredentialResponse = serde_json::from_value(serialized).unwrap();
+        assert_eq!(deserialized, credential_response);
+    }
+
+    #[test]
+    fn test_credential_response_many() {
+        let credential_response = CredentialResponse {
+            credential: CredentialResponseType::Immediate {
+                credential: json!(["123".to_string(), "abc".to_string()]),
+                notification_id: None,
+            },
+            c_nonce: Some("456".to_string()),
+            c_nonce_expires_in: Some(789),
+        };
+        let serialized = serde_json::to_value(&credential_response).unwrap();
+        assert_eq!(
+            serialized,
+            json!({
+                "credential": ["123", "abc"], // XXX or credential_s_
                 "c_nonce": "456",
                 "c_nonce_expires_in": 789
             })

--- a/oid4vci/src/proof.rs
+++ b/oid4vci/src/proof.rs
@@ -22,6 +22,14 @@ impl KeyProofType {
     }
 }
 
+// Key Proof_s_ type for multiple proof-of-posessions in the same credential request
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum KeyProofsType {
+    Jwt(Vec<String>),
+    Cwt(Vec<String>),
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct KeyProofMetadata {
     pub proof_signing_alg_values_supported: Vec<String>,

--- a/oid4vci/src/wallet/mod.rs
+++ b/oid4vci/src/wallet/mod.rs
@@ -11,8 +11,9 @@ use crate::credential_issuer::{
 use crate::credential_offer::{AuthorizationRequestReference, CredentialOfferParameters};
 use crate::credential_request::{
     BatchCredentialRequest, CredentialRequest, CredentialResponseEncryptionKey,
-    CredentialResponseEncryptionSpecification,
+    CredentialResponseEncryptionSpecification, OneOrManyKeyProofs,
 };
+use OneOrManyKeyProofs::{Proof, Proofs};
 use crate::credential_response::{BatchCredentialResponse, CredentialResponseType};
 use crate::proof::{KeyProofType, ProofType};
 use crate::wallet::content_encryption::ContentDecryptor;
@@ -232,7 +233,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
         let timestamp = SystemTime::now();
         let timestamp = timestamp.duration_since(UNIX_EPOCH).expect("Time went backwards");
         let proof = if c_nonce.is_some() {
-            Some(
+            Proof(Some(
                 KeyProofType::builder()
                     .proof_type(ProofType::Jwt)
                     .signer(self.subject.clone())
@@ -244,9 +245,9 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
                     .subject_syntax_type(self.default_subject_syntax_type.to_string())
                     .build()
                     .await?,
-            )
+            ))
         } else {
-            None
+            Proof(None)
         };
         let credential_response_encryption = if let Some(content_decryptor) = content_decryptor.as_ref() {
             Some(content_decryptor.encryption_specification())
@@ -294,7 +295,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
 
             println!("using c_nonce --> {c_nonce}");
 
-            let proof = Some(
+            let proof = Proof(Some(
                 KeyProofType::builder()
                     .proof_type(ProofType::Jwt)
                     .signer(self.subject.clone())
@@ -311,7 +312,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
                     .subject_syntax_type(self.default_subject_syntax_type.to_string())
                     .build()
                     .await?,
-            );
+            ));
 
             let credential_request = CredentialRequest {
                 credential_format: credential_format.clone(),
@@ -380,7 +381,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
             enc: "A128CBC-HS256".to_string(),
             alg: "RSA-OAEP-256".to_string(),
         };
-        let proof = Some(
+        let proof = Proof(Some(
             KeyProofType::builder()
                 .proof_type(ProofType::Jwt)
                 .signer(self.subject.clone())
@@ -403,7 +404,7 @@ impl<CFC: CredentialFormatCollection + DeserializeOwned> Wallet<CFC> {
                 .subject_syntax_type(self.default_subject_syntax_type.to_string())
                 .build()
                 .await?,
-        );
+        ));
 
         let batch_credential_request = BatchCredentialRequest {
             credential_requests: credential_formats


### PR DESCRIPTION
Extend `get_credential` request to support requesting multiple credentials by submitting multiple proof-of-posessions `proofs` instead of a single `proof`.

Hacky, incomplete, and not tested.